### PR TITLE
Fix mobile category cards layout to display 2x2 grid without horizontal scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -1078,7 +1078,7 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
             .about-header h2 { font-size: 1.6rem; }
             .features-grid { grid-template-columns: 1fr; gap: 0.9rem; }
             .category-section-title { font-size: 1.35rem; margin-top: 0.65rem; margin-bottom: 0.9rem; }
-            .categories.container { grid-template-columns: repeat(2, 1fr); gap: 0.65rem; padding-left: 0.9rem; padding-right: 0.9rem; padding-top: 0; padding-bottom: 0.45rem; }
+            .categories.container { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.65rem; padding-left: 0.9rem; padding-right: 0.9rem; padding-top: 0; padding-bottom: 0.45rem; }
             .category { padding: 0.9rem 0.65rem; border-radius: 11px; }
             .category-icon-wrapper { width: 45px; height: 45px; border-radius: 9px; margin-bottom: 0.65rem; }
             .category i.category-icon-fa { font-size: 1.4rem; }
@@ -1186,7 +1186,7 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
             .orders-notification {top: -4px; right: -4px; font-size: 0.65rem; width: 14px; height: 14px; }
             .product-detail-page { padding: 0.45rem 0.35rem; }
             .category-section-title { font-size: 1.15rem; }
-            .categories.container { gap: 0.45rem; padding-left: 0.65rem; padding-right: 0.65rem; padding-top: 0; padding-bottom: 0.22rem; }
+            .categories.container { display: grid; gap: 0.45rem; padding-left: 0.65rem; padding-right: 0.65rem; padding-top: 0; padding-bottom: 0.22rem; }
             .category-icon-wrapper { width: 40px; height: 40px; border-radius: 7px;}
             .category i.category-icon-fa { font-size: 1.25rem; }
             .category-name { font-size: 0.8rem; }


### PR DESCRIPTION
## Problem
The product category cards on mobile view were overflowing beyond the screen width, requiring horizontal scrolling to see all cards. Although the CSS was set to display two cards per row, they didn't fit properly within the mobile screen.

## Solution
Added `display: grid` property to the mobile CSS rules for `.categories.container` at both breakpoints:
- `@media (max-width: 768px)` 
- `@media (max-width: 480px)`

## Changes Made
- **Line 1081**: Added `display: grid;` to `.categories.container` for tablets/large phones
- **Line 1189**: Added `display: grid;` to `.categories.container` for small phones

## Result
✅ **Perfect 2x2 grid layout**: Course and Subscription on top row, Software and Ebook on bottom row  
✅ **No horizontal scrolling**: All cards fit perfectly within mobile screen width  
✅ **Responsive design**: Works across different mobile screen sizes  
✅ **Preserved styling**: Maintains existing design, spacing, and visual appearance  
✅ **Clean implementation**: Minimal change with maximum impact  

## Testing
- Tested on mobile viewport (768px and below)
- Tested on smaller mobile screens (480px and below)
- Verified no horizontal overflow
- Confirmed proper spacing and card sizing
- Ensured design consistency across breakpoints

## Screenshots
The category cards now display in a proper 2x2 grid layout on mobile devices without any horizontal scrolling, exactly as requested.

@raihanxyz-coder can click here to [continue refining the PR](https://app.all-hands.dev/conversations/06f8fadeff9249a1ba8b0a7ae1719381)